### PR TITLE
Update dependency to H5P.DragNBar

### DIFF
--- a/library.json
+++ b/library.json
@@ -2,7 +2,7 @@
   "title": "Image Multiple Hotspot Question Editor",
   "majorVersion": 1,
   "minorVersion": 0,
-  "patchVersion": 0,
+  "patchVersion": 1,
   "runnable": 0,
   "author": "Luke Muller",
   "coreApi": {
@@ -24,7 +24,7 @@
     {
       "machineName": "H5P.DragNBar",
       "majorVersion": 1,
-      "minorVersion": 4
+      "minorVersion": 5
     },
     {
       "machineName": "H5P.DragNResize",


### PR DESCRIPTION
Find Multiple Hotspots is the last content type using the old version of DragNBar thus blocking the old library from being removed.